### PR TITLE
Support string alias type's ToStringE and ToString functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # cast
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/spf13/cast/ci.yaml?branch=master&style=flat-square)](https://github.com/spf13/cast/actions/workflows/ci.yaml)
-[![PkgGoDev](https://pkg.go.dev/badge/mod/github.com/spf13/cast)](https://pkg.go.dev/mod/github.com/spf13/cast)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PeterlitsZo/cast/ci.yaml?branch=master&style=flat-square)](https://github.com/PeterlitsZo/cast/actions/workflows/ci.yaml)
+[![PkgGoDev](https://pkg.go.dev/badge/mod/github.com/PeterlitsZo/cast)](https://pkg.go.dev/mod/github.com/PeterlitsZo/cast)
 ![Go Version](https://img.shields.io/badge/go%20version-%3E=1.16-61CFDD.svg?style=flat-square)
-[![Go Report Card](https://goreportcard.com/badge/github.com/spf13/cast?style=flat-square)](https://goreportcard.com/report/github.com/spf13/cast)
+[![Go Report Card](https://goreportcard.com/badge/github.com/PeterlitsZo/cast?style=flat-square)](https://goreportcard.com/report/github.com/PeterlitsZo/cast)
 
 Easy and safe casting from one type to another in Go
 
 Don’t Panic! ... Cast
+
+> This project is forked from `spf13/cast`, See section **What's New** to know more.
 
 ## What is Cast?
 
@@ -73,3 +75,15 @@ the code for a complete set.
 	var eight interface{} = 8
     cast.ToInt(eight)              // 8
     cast.ToInt(nil)                // 0
+
+### What's new
+
+- `v0.1.0`:
+    - The original version forked from `spf13/cast`.
+- `v0.1.1`:
+    - Support string-alias type's `ToStringE` and `ToString` function.
+
+      ```go
+      type StrAlias string
+      ToString(StrAlias("foobar")) // "foobar"
+      ```

--- a/cast_test.go
+++ b/cast_test.go
@@ -233,10 +233,14 @@ func TestToStringE(t *testing.T) {
 
 	var jn json.Number
 	_ = json.Unmarshal([]byte("8"), &jn)
+
 	type Key struct {
 		k string
 	}
 	key := &Key{"foo"}
+
+	type StrAlias string
+	sa := StrAlias("bar")
 
 	tests := []struct {
 		input  interface{}
@@ -266,6 +270,8 @@ func TestToStringE(t *testing.T) {
 		{template.JS("(1+2)"), "(1+2)", false},
 		{template.CSS("a"), "a", false},
 		{template.HTMLAttr("a"), "a", false},
+		{sa, "bar", false},
+
 		// errors
 		{testing.T{}, "", true},
 		{key, "", true},

--- a/caste.go
+++ b/caste.go
@@ -911,7 +911,7 @@ func indirect(a interface{}) interface{} {
 // Copyright 2011 The Go Authors. All rights reserved.
 // indirectToStringerOrError returns the value, after dereferencing as many times
 // as necessary to reach the base type (or nil) or an implementation of fmt.Stringer
-// or error,
+// or error.
 func indirectToStringerOrError(a interface{}) interface{} {
 	if a == nil {
 		return nil
@@ -980,6 +980,12 @@ func ToStringE(i interface{}) (string, error) {
 		return s.String(), nil
 	case error:
 		return s.Error(), nil
+	}
+
+	iReflectVal := reflect.ValueOf(i)
+	switch iReflectVal.Kind() {
+	case reflect.String:
+		return iReflectVal.String(), nil
 	default:
 		return "", fmt.Errorf("unable to cast %#v of type %T to string", i, i)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/spf13/cast
+module github.com/PeterlitsZo/cast
 
 go 1.19
 


### PR DESCRIPTION
Now we support:

```go
type StrAlias string
ToString(StrAlias("bar")) // "bar"
```